### PR TITLE
Implement --addresses & --basenames to supplement --list-frameworks

### DIFF
--- a/bin/dyldex
+++ b/bin/dyldex
@@ -74,6 +74,10 @@ def _getArguments():
 		help="List addresses along with framework paths. Only applies when --list-frameworks is specified."
 	)
 	parser.add_argument(
+		"-b", "--basenames", action="store_true",
+		help="Print only the basenames of each framework. Only applies when --list-frameworks is specified."
+	)
+	parser.add_argument(
 		"-v", "--verbosity", type=int, choices=[0, 1, 2, 3], default=1,
 		help="Increase verbosity, Option 1 is the default. | 0 = None | 1 = Critical Error and Warnings | 2 = 1 + Info | 3 = 2 + debug |"  # noqa
 	)
@@ -213,9 +217,10 @@ def main():
 			sortedPaths = sorted(imagePaths, key=lambda path: imageMap[path].address)
 
 			print("Listing Images\n--------------")
-			for path in sortedPaths:
+			for fullpath in sortedPaths:
+				path = os.path.basename(fullpath) if args.basenames else fullpath
 				if args.addresses:
-					print(f"{hex(imageMap[path].address)} : {path}")
+					print(f"{hex(imageMap[fullpath].address)} : {path}")
 				else:
 					print(path)
 

--- a/bin/dyldex
+++ b/bin/dyldex
@@ -70,6 +70,10 @@ def _getArguments():
 		help="Filter out frameworks when listing them."
 	)
 	parser.add_argument(
+		"-a", "--addresses", action="store_true",
+		help="List addresses along with framework paths. Only applies when --list-frameworks is specified."
+	)
+	parser.add_argument(
 		"-v", "--verbosity", type=int, choices=[0, 1, 2, 3], default=1,
 		help="Increase verbosity, Option 1 is the default. | 0 = None | 1 = Critical Error and Warnings | 2 = 1 + Info | 3 = 2 + debug |"  # noqa
 	)
@@ -203,11 +207,17 @@ def main():
 			# filter if needed
 			if args.filter:
 				filterTerm = args.filter.strip().lower()
-				imagePaths = _filterImages(imagePaths, filterTerm)
+				imagePaths = set(_filterImages(imagePaths, filterTerm))
+
+			# sort the paths so they're displayed in VM address order
+			sortedPaths = sorted(imagePaths, key=lambda path: imageMap[path].address)
 
 			print("Listing Images\n--------------")
-			for path in imagePaths:
-				print(path)
+			for path in sortedPaths:
+				if args.addresses:
+					print(f"{hex(imageMap[path].address)} : {path}")
+				else:
+					print(path)
 
 			return
 


### PR DESCRIPTION
I desired to use this tool in order to aid navigating the shared cache with Hopper. Specifically I wanted to have an address and determine which framework it came from so that I can open that binary up in Hopper alongside the original binary (e.g. in UIKitCore there's a call to some function at `0x180918930`, I wanted to know what function this is, but first I need to figure out which image it's coming from).

In order to solve this I implemented `-a/--addresses` which prints out the addresses of each image along with the image name. Along the way I also sorted the image list to be printed in VM address order so that it's a bit easier to navigate visually.

I also implemented `--basenames` since most of the time (all of the time?) there aren't any images with colliding base names. This also makes navigating the output of `--list-frameworks` a bit easier.

P.S. If I'm way off base for making this PR feel free to let me know. Just figured these changes might be helpful to folks outside myself.