### PR TITLE
[dyldex] Add --lookup to quickly find the image an address lives in

### DIFF
--- a/bin/dyldex
+++ b/bin/dyldex
@@ -76,6 +76,10 @@ def _getArguments():
 	parser.add_argument(
 		"-b", "--basenames", action="store_true",
 		help="Print only the basenames of each framework. Only applies when --list-frameworks is specified."
+		)
+	parser.add_argument(
+		"--lookup",
+		help="Find the library that an address lives in. Address should be specified as hex. E.g. dyldex --lookup 0x18008e9f8 dyld_shared_cache_arm64e."
 	)
 	parser.add_argument(
 		"-v", "--verbosity", type=int, choices=[0, 1, 2, 3], default=1,
@@ -203,6 +207,31 @@ def main():
 			path = path.decode("utf-8")
 
 			imageMap[path] = imageData
+
+		# Find the image that an address lives in
+		if args.lookup:
+			lookupAddr = int(args.lookup, 16)
+
+			imagePaths = imageMap.keys()
+
+			# sort the paths so they're in VM address order
+			sortedPaths = sorted(imagePaths, key=lambda path: imageMap[path].address)
+
+			previousImagePath = None
+			for path in sortedPaths:
+				imageAddr = imageMap[path].address
+				if lookupAddr < imageAddr:
+					if previousImagePath is None:
+						print("Error: address before first image!", file=sys.stderr)
+						sys.exit(1)
+					print(os.path.basename(previousImagePath) if args.basenames else previousImagePath)
+					return
+				else:
+					previousImagePath = path
+			# We got to the end of the list, must be the last image
+			path = sortedPaths[-1]
+			print(os.path.basename(path) if args.basenames else path)
+			return
 
 		# list images option
 		if args.list_frameworks:

--- a/bin/dyldex
+++ b/bin/dyldex
@@ -79,7 +79,7 @@ def _getArguments():
 		)
 	parser.add_argument(
 		"--lookup",
-		help="Find the library that an address lives in. Address should be specified as hex. E.g. dyldex --lookup 0x18008e9f8 dyld_shared_cache_arm64e."
+		help="Find the library that an address lives in. E.g. dyldex --lookup 0x18008e9f8 dyld_shared_cache_arm64e."
 	)
 	parser.add_argument(
 		"-v", "--verbosity", type=int, choices=[0, 1, 2, 3], default=1,
@@ -210,7 +210,7 @@ def main():
 
 		# Find the image that an address lives in
 		if args.lookup:
-			lookupAddr = int(args.lookup, 16)
+			lookupAddr = int(args.lookup, 0)
 
 			imagePaths = imageMap.keys()
 


### PR DESCRIPTION
Following on #42 I wanted to optimize the "find the image this address lives in" workflow further. This PR introduces a new flag `--lookup` which allows the user to supply a hex address and the tool will print out the image it should live in (assuming the images are contiguous in memory, which I think is the case). Example usage:
```sh
> dyldex -b dyld_shared_cache_arm64e --look 0x18008e9f8
libdispatch.dylib
```