### PR TITLE
Added missing import

### DIFF
--- a/src/DyldExtractor/objc/objc_structs.py
+++ b/src/DyldExtractor/objc/objc_structs.py
@@ -1,6 +1,7 @@
 from ctypes import (
 	c_int32,
 	c_uint32,
+	c_int64,
 	c_uint64
 )
 


### PR DESCRIPTION
The `c_int64` type was missing from the import list (used in line 311).