### PR TITLE
Fix TypeError in resource limits handling

### DIFF
--- a/bin/dyldex
+++ b/bin/dyldex
@@ -9,11 +9,12 @@ import sys
 from typing import List, BinaryIO
 
 try:
-    import resource
-    resource.setrlimit(resource.RLIMIT_NOFILE, (1024, resource.getrlimit(resource.RLIMIT_NOFILE)))
+	import resource
+	soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+	resource.setrlimit(resource.RLIMIT_NOFILE, (1024, hard))
 except ImportError:
-    # resource module is not avilable on windows
-    pass
+	# resource module is not available on windows
+	pass
 
 try:
 	progressbar.streams

--- a/bin/dyldex_all
+++ b/bin/dyldex_all
@@ -11,11 +11,12 @@ import sys
 import progressbar
 
 try:
-    import resource
-    resource.setrlimit(resource.RLIMIT_NOFILE, (1024, resource.getrlimit(resource.RLIMIT_NOFILE)))
+	import resource
+	soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+	resource.setrlimit(resource.RLIMIT_NOFILE, (1024, hard))
 except ImportError:
-    # resource module is not avilable on windows
-    pass
+	# resource module is not available on windows
+	pass
 
 from typing import (
 	List,


### PR DESCRIPTION
Fixes TypeError crash when setting resource limits introduced in #64

The previous code attempted to use the entire tuple returned by `getrlimit()` as the hard limit value. This change extracts the hard limit from the tuple before setting the new limits.

Error fixed:
```python
Traceback (most recent call last):
  File "/Users/ethanarbuckle/Desktop/DyldExtractor/./bin/dyldex_all", line 15, in <module>
    resource.setrlimit(resource.RLIMIT_NOFILE, (1024, resource.getrlimit(resource.RLIMIT_NOFILE)))
TypeError: 'tuple' object cannot be interpreted as an integer
```

Changes:
- Extract hard limit from getrlimit() tuple
- Fix typo in "available" comment
- Consistent indents


Issue: https://github.com/arandomdev/DyldExtractor/issues/65