### PR TITLE
Fix local symbols in `__auth_got`

### DIFF
--- a/src/DyldExtractor/converter/stub_fixer.py
+++ b/src/DyldExtractor/converter/stub_fixer.py
@@ -1414,6 +1414,10 @@ class _StubFixer(object):
 								continue
 
 							elif stubFormat == _StubFormat.AuthStubNormal:
+								if symbolIndex == INDIRECT_SYMBOL_LOCAL:
+									# No fix needed
+									continue
+
 								# only need to relink symbol pointer
 								symPtrOff = self._dyldCtx.convertAddr(symPtrAddr)[0]
 


### PR DESCRIPTION
Ignore stub fixing for `INDIRECT_SYMBOL_LOCAL` symbols in `__auth_got`.

Issue: #70 

After the fix:

<img width="1670" height="766" alt="image" src="https://github.com/user-attachments/assets/200026d5-9876-4bdf-888d-88d36ab2658b" />
